### PR TITLE
Fix Docker image tag handling in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,13 +195,23 @@ jobs:
       - name: Generate Docker Image Tag
         id: docker-tag
         run: |
+          # Generate tag based on git SHA or 'latest'
           if [[ "${{ env.VERSION_STRATEGY }}" == "git-sha" ]]; then
             SHORT_SHA=$(git rev-parse --short HEAD)
+            # Set output for this step
+            echo "tag=${SHORT_SHA}" >> $GITHUB_OUTPUT
+            # Set env var for subsequent steps
             echo "IMAGE_TAG=${SHORT_SHA}" >> $GITHUB_ENV
           else
+            echo "tag=latest" >> $GITHUB_OUTPUT
             echo "IMAGE_TAG=latest" >> $GITHUB_ENV
           fi
-          echo "FULL_IMAGE_NAME=${{ secrets.ECR_REPOSITORY_URI }}:${IMAGE_TAG}" >> $GITHUB_ENV
+          
+      - name: Set Full Image Name
+        run: |
+          # Use the tag output from previous step
+          echo "FULL_IMAGE_NAME=${{ secrets.ECR_REPOSITORY_URI }}:${{ steps.docker-tag.outputs.tag }}" >> $GITHUB_ENV
+          echo "Will build image: ${{ secrets.ECR_REPOSITORY_URI }}:${{ steps.docker-tag.outputs.tag }}"
           
       - name: Build Docker Image for ECR
         run: |


### PR DESCRIPTION
## Summary
- Fixed issue with Docker image tag not being properly applied in the workflow
- Split tag generation and full image name creation into separate steps
- Added proper GitHub Actions outputs for steps
- Added logging to verify correct tag usage

## Issue Fixed
The Docker build was failing with error 'invalid tag "***:": invalid reference format' because the image tag wasn't being properly applied to the full image name.

## Test plan
- Verify that Docker build step completes successfully
- Confirm image tag is properly applied to the Docker image

🤖 Generated with [Claude Code](https://claude.ai/code)